### PR TITLE
Use glib.get_user_cache_dir() to find cache directory.

### DIFF
--- a/gpxviewer/ui.py
+++ b/gpxviewer/ui.py
@@ -21,6 +21,7 @@
 #
 import os
 import sys
+import glib
 import gtk
 import gobject
 
@@ -152,7 +153,9 @@ class MainWindow:
 		self.ui_dir = ui_dir
 
 		self.map = osmgpsmap.GpsMap(
-					tile_cache=os.path.expanduser('~/.cache/gpxviewer/tiles/'))
+					tile_cache=os.path.join(
+						glib.get_user_cache_dir(),
+						'gpxviewer', 'tiles'))
 		self.map.layer_add(
 					osmgpsmap.GpsMapOsd(
 						show_dpad=False,


### PR DESCRIPTION
This is just a quick change to support users(like me) who have a non-default [XDG_CACHE_HOME](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) setting.

Thanks,

James
