### PR TITLE
Fix initialization warnings

### DIFF
--- a/gpxviewer/ui.py
+++ b/gpxviewer/ui.py
@@ -22,6 +22,11 @@
 import os
 import sys
 
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('Gdk', '3.0')
+gi.require_version('OsmGpsMap', '1.0')
+gi.require_version('PangoCairo', '1.0')
 from gi.repository import GLib
 from gi.repository import Gtk
 from gi.repository import Gdk
@@ -455,11 +460,12 @@ class MainWindow:
 		if _iter:
 			trace, OsmGpsMapTracks = self.trackManager.getTraceFromModel(_iter)
 			colorseldlg = Gtk.ColorSelectionDialog("Select track color")
-			colorseldlg.get_color_selection().set_current_color(OsmGpsMapTracks[0].props.color)
+			colorseldlg.get_color_selection().set_current_rgba(OsmGpsMapTracks[0].props.color)
+			colorseldlg.set_transient_for(self.mainWindow)
 			result = colorseldlg.run()
 			if result == Gtk.ResponseType.OK:
 				color = colorseldlg.get_color_selection().get_current_rgba()
-				print color
+				#print color
 				for OsmGpsMapTrack in OsmGpsMapTracks:
 					OsmGpsMapTrack.set_color(color)
 					self.map.map_redraw()

--- a/main.py
+++ b/main.py
@@ -26,8 +26,8 @@ parent_dir = os.path.dirname(os.path.abspath(__file__))
 source_dir = os.path.join(parent_dir, "gpxviewer")
 sys.path.append(source_dir)
 
-from gi.repository import Gdk
 from gpxviewer.ui import MainWindow
+from gi.repository import Gdk
  
 Gdk.threads_init()
 


### PR DESCRIPTION
This PR remove some warnings dumped to the console.

* `PyGIWarning: xxxx was imported without specifying a version first.` just after launch gpxviewer.
* `TypeError: argument color: Expected Gdk.Color, but got gi.overrides.Gdk.RGBA` after click on "Properties" button.
* `GtkDialog mapped without a transient parent. This is discouraged.` after click on "Properties" button.